### PR TITLE
chore: update ci workflow to leverage codecov instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Pytest with coverage reporting
         run: pytest --cov=sharkiq --junitxml=junit.xml -o junit_family=legacy
       - name: Upload coverage to Codecov
-        if: matrix.python-version == 3.13 && matrix.os == 'ubuntu'
+        if: matrix.python-version == 3.13 && matrix.os == 'ubuntu' && ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,13 @@ jobs:
           pip install -r requirements.txt
           pip list
       - name: Pytest with coverage reporting
-        run: pytest --cov=sharkiq --cov-report=xml
+        run: pytest --cov=sharkiq --junitxml=junit.xml -o junit_family=legacy
       - name: Upload coverage to Codecov
         if: matrix.python-version == 3.13 && matrix.os == 'ubuntu'
-        uses: codecov/codecov-action@v5.5.0
+        uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
+
   docs:
     name: Generate and Upload Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update GH workflow to follow codecov's exact install instructions
<img width="776" height="666" alt="image" src="https://github.com/user-attachments/assets/e25eaff6-6b58-45ee-a6a1-4b1007f3dcaa" />
