### PR TITLE
fix: codecov action should be files, not file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: codecov/codecov-action@v5.5.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
   docs:


### PR DESCRIPTION
Codecov action should be files, not file. See [their usage](https://github.com/codecov/codecov-action?tab=readme-ov-file#usage) for example.