### PR TITLE
fix: using europe endpoints when in europe mode

### DIFF
--- a/sharkiq/ayla_api.py
+++ b/sharkiq/ayla_api.py
@@ -231,7 +231,7 @@ class AylaApi:
 
         if use_auth0:
             AsyncGetToken = asyncify(GetToken)
-            get_token = AsyncGetToken(AUTH0_HOST, AUTH0_CLIENT_ID)
+            get_token = AsyncGetToken(EU_AUTH0_HOST if self.europe else AUTH0_HOST, EU_AUTH0_CLIENT_ID if self.europe else AUTH0_CLIENT_ID)
 
             auth_result = await get_token.login_async(
                 username=self._email,


### PR DESCRIPTION
The Ayla Auth0 api was not using the EU enpoints for auth0 when in europe mode which caused the no state returned from /authorized error.

It can maybe close the issue in https://github.com/home-assistant/core/issues/152339.