### PR TITLE
feat: add Skegox API backend for newer SharkNinja devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ dmypy.json
 # IDE files
 .idea/
 .vscode/
+.vs/
 
 # Secrets
 secrets.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "aiohttp>=3.8.1",
     "auth0-python>=4.10.0",
     "requests>=2.27.1",
+    "protobuf>=4.21.0",
 ]
 
 [project.urls]
@@ -32,6 +33,9 @@ Repository = "https://github.com/sharkiqlibs/sharkiq"
 Issues = "https://github.com/sharkiqlibs/sharkiq/issues"
 
 [project.optional-dependencies]
+floorplan = [
+    "Pillow>=9.0.0",
+]
 test = [
     "pytest==8.4.2",
     "pytest-asyncio==1.2.0",

--- a/sharkiq/__init__.py
+++ b/sharkiq/__init__.py
@@ -1,23 +1,60 @@
 """Unofficial SDK for Shark IQ robot vacuums, designed primarily to support an integration for Home Assistant."""
 
+from typing import Any, Callable
+
 from .ayla_api import AylaApi, get_ayla_api, Auth0Client
 from .exc import (
     SharkIqError,
     SharkIqAuthExpiringError,
     SharkIqNotAuthedError,
     SharkIqAuthError,
+    SharkIqAuthVerificationRequiredError,
     SharkIqReadOnlyPropertyError,
+    SkegoxApiError,
+    SkegoxAuthError,
+    SkegoxAuthRequiresVerificationError,
+    SkegoxAuthLockedError,
 )
-from .sharkiq import OperatingModes, PowerModes,  Properties, SharkIqVacuum
+from .sharkiq import OperatingModes, PowerModes, Properties, SharkIqVacuum, ERROR_MESSAGES
+from .skegox_auth import SkegoxAuthManager, AuthTokens
+from .skegox_api import SkegoxApi
+from .skegox_device import SkegoxDevice
+from .const import RegionConfig, REGION_CONFIGS, REGION_ELSEWHERE, REGION_EUROPE
 
 try:
     from importlib.metadata import version, PackageNotFoundError
 except ImportError:
-    # Python < 3.8
     from importlib_metadata import version, PackageNotFoundError
 
 try:
     __version__ = version("sharkiq")
 except PackageNotFoundError:
-    # Package is not installed
     __version__ = "unknown"
+
+def get_skegox_api(
+    username: str,
+    password: str,
+    region: str = REGION_ELSEWHERE,
+    token_store: dict[str, Any] | None = None,
+    on_tokens_changed: Callable[[dict[str, Any]], None] | None = None,
+) -> SkegoxApi:
+    """Get a SkegoxApi instance with an embedded SkegoxAuthManager.
+
+    Args:
+        username: Auth0 username (email).
+        password: Auth0 password.
+        region: Region key ("elsewhere" or "europe").
+        token_store: Initial token dict (e.g., from persistent storage).
+        on_tokens_changed: Callback invoked whenever tokens are updated.
+
+    Returns:
+        A SkegoxApi instance ready for use.
+    """
+    auth_manager = SkegoxAuthManager(
+        username=username,
+        password=password,
+        region=region,
+        token_store=token_store,
+        on_tokens_changed=on_tokens_changed,
+    )
+    return SkegoxApi(auth_manager)

--- a/sharkiq/ayla_api.py
+++ b/sharkiq/ayla_api.py
@@ -35,7 +35,7 @@ from .const import (
     EU_AUTH0_TOKEN_URL,
     EU_AUTH0_CLIENT_ID
 )
-from .exc import SharkIqAuthError, SharkIqAuthExpiringError, SharkIqNotAuthedError
+from .exc import SharkIqAuthError, SharkIqAuthExpiringError, SharkIqNotAuthedError, SharkIqAuthVerificationRequiredError
 from .fallback_auth import FallbackAuth
 from .sharkiq import SharkIqVacuum
 
@@ -270,7 +270,12 @@ class AylaApi:
             timeout=15,
         ) as resp:
             if resp.status >= 400:
-                raise SharkIqAuthError(f"Auth0 password grant failed: {resp.status} {await resp.text()}")
+                body = await resp.text()
+                if "requires_verification" in body:
+                    raise SharkIqAuthVerificationRequiredError(
+                        f"Auth0 requires verification: {body}"
+                    )
+                raise SharkIqAuthError(f"Auth0 password grant failed: {resp.status} {body}")
             auth0_json = await resp.json()
         if "id_token" not in auth0_json:
             raise SharkIqAuthError("Auth0 response missing id_token")
@@ -299,7 +304,12 @@ class AylaApi:
                     self._password
                 )
                 self._auth0_id_token = auth_result["id_token"]
+        except SharkIqAuthVerificationRequiredError:
+            raise
         except Exception as err:
+            err_str = str(err).lower()
+            if "suspicious request requires verification" in err_str or "requires_verification" in err_str:
+                raise SharkIqAuthVerificationRequiredError(str(err)) from err
             if not force_auth0_sdk:
                 # Retry with Auth0 SDK path as a last resort
                 return await self._legacy_cookie_sign_in(ayla_client, force_auth0_sdk=True)
@@ -315,6 +325,8 @@ class AylaApi:
 
         try:
             await self._password_grant_sign_in(ayla_client)
+        except SharkIqAuthVerificationRequiredError:
+            raise
         except Exception:
             # Password grant failed; try legacy flow (will raise if it also fails)
             await self._legacy_cookie_sign_in(ayla_client)

--- a/sharkiq/const.py
+++ b/sharkiq/const.py
@@ -27,6 +27,10 @@ API_TIMEOUT = 20
 REGION_ELSEWHERE = "elsewhere"
 REGION_EUROPE = "europe"
 
+# Power mode mappings shared between Ayla and Skegox backends
+AYLA_TO_SKEGOX_POWER = {1: 0, 0: 1, 2: 2}  # ECO=1->0, NORMAL=0->1, MAX=2->2
+SKEGOX_TO_AYLA_POWER = {v: k for k, v in AYLA_TO_SKEGOX_POWER.items()}
+
 @dataclass(frozen=True)
 class RegionConfig:
     auth0_url: str

--- a/sharkiq/const.py
+++ b/sharkiq/const.py
@@ -1,4 +1,6 @@
 """Various constants"""
+from dataclasses import dataclass
+
 AUTH0_URL = "https://login.sharkninja.com"
 AUTH0_HOST = "login.sharkninja.com"
 AUTH0_CLIENT_ID = "wsguxrqm77mq4LtrTrwg8ZJUxmSrexGi"
@@ -19,3 +21,51 @@ EU_DEVICE_URL = "https://ads-eu.aylanetworks.com"
 EU_LOGIN_URL = "https://user-field-eu.aylanetworks.com"
 EU_SHARK_APP_ID = "android_shark_prod-lg-id"
 EU_SHARK_APP_SECRET = "android_shark_prod-xuf9mlHOo0p3Ty5bboFROSyRBlE"
+
+API_TIMEOUT = 20
+
+REGION_ELSEWHERE = "elsewhere"
+REGION_EUROPE = "europe"
+
+@dataclass(frozen=True)
+class RegionConfig:
+    auth0_url: str
+    auth0_token_url: str
+    auth0_host: str
+    auth0_client_id: str
+    auth0_scopes: str
+    ayla_login_url: str
+    ayla_device_url: str
+    ayla_app_id: str
+    ayla_app_secret: str
+    skegox_base: str
+    skegox_api_key: str
+
+REGION_CONFIGS: dict[str, RegionConfig] = {
+    REGION_ELSEWHERE: RegionConfig(
+        auth0_url="https://login.sharkninja.com",
+        auth0_token_url="https://login.sharkninja.com/oauth/token",
+        auth0_host="login.sharkninja.com",
+        auth0_client_id="wsguxrqm77mq4LtrTrwg8ZJUxmSrexGi",
+        auth0_scopes="openid email profile offline_access",
+        ayla_login_url="https://user-sharkue1.aylanetworks.com",
+        ayla_device_url="https://ads-sharkue1.aylanetworks.com",
+        ayla_app_id="ios_shark_prod-3A-id",
+        ayla_app_secret="ios_shark_prod-74tFWGNg34LQCmR0m45SsThqrqs",
+        skegox_base="https://stakra.slatra.thor.skegox.com",
+        skegox_api_key="QQdbSrgicK2PxvACI1a2P5AN2xgO78Lw1VvnYczb",
+    ),
+    REGION_EUROPE: RegionConfig(
+        auth0_url="https://logineu.sharkninja.com",
+        auth0_token_url="https://logineu.sharkninja.com/oauth/token",
+        auth0_host="logineu.sharkninja.com",
+        auth0_client_id="rKDx9O18dBrY3eoJMTkRiBZHDvd9Mx1I",
+        auth0_scopes="openid email profile offline_access",
+        ayla_login_url="https://user-field-eu.aylanetworks.com",
+        ayla_device_url="https://ads-eu.aylanetworks.com",
+        ayla_app_id="android_shark_prod-lg-id",
+        ayla_app_secret="android_shark_prod-xuf9mlHOo0p3Ty5bboFROSyRBlE",
+        skegox_base="https://stakra.rannsaka.thor.skegox.com",
+        skegox_api_key="T5m8d45crZDV9I5aCEZr4n2gSqJW64r2RNXqqhh1",
+    ),
+}

--- a/sharkiq/exc.py
+++ b/sharkiq/exc.py
@@ -27,7 +27,27 @@ class SharkIqNotAuthedError(SharkIqError):
     def __init__(self, msg=NOT_AUTHED_MESSAGE, *args):
         super().__init__(msg, *args)
 
+class SharkIqAuthVerificationRequiredError(SharkIqAuthError):
+    """Exception when Auth0 requires additional verification (MFA/CAPTCHA/suspicious request)."""
+    def __init__(self, msg="SharkNinja is blocking automated login (anti-bot protection). Wait 24-48 hours, then try again.", *args):
+        super().__init__(msg, *args)
+
 
 class SharkIqReadOnlyPropertyError(SharkIqError):
     """Tried to set a read-only property"""
     pass
+
+class SkegoxApiError(SharkIqError):
+    """Skegox API request failure."""
+
+
+class SkegoxAuthError(SharkIqError):
+    """Authentication failure with the Skegox/Auth0 API."""
+
+
+class SkegoxAuthRequiresVerificationError(SkegoxAuthError):
+    """Auth0 requires additional verification (MFA, CAPTCHA, etc.)."""
+
+
+class SkegoxAuthLockedError(SkegoxAuthError):
+    """Account locked or rate-limited — do not retry."""

--- a/sharkiq/sharkiq.py
+++ b/sharkiq/sharkiq.py
@@ -122,21 +122,27 @@ class Properties(enum.Enum):
 
 
 ERROR_MESSAGES = {
+    0: "No error",
     1: "Side wheel is stuck",
     2: "Side brush is stuck",
     3: "Suction motor failed",
     4: "Brushroll stuck",
-    5: "Side wheel is stuck (2)",
+    5: "Charging error",
     6: "Bumper is stuck",
     7: "Cliff sensor is blocked",
     8: "Battery power is low",
-    9: "No Dustbin",
+    9: "No dustbin",
     10: "Fall sensor is blocked",
     11: "Front wheel is stuck",
+    12: "Wrong power adapter",
     13: "Switched off",
     14: "Magnetic strip error",
     16: "Top bumper is stuck",
     18: "Wheel encoder error",
+    21: "Boot error",
+    23: "Base placement error",
+    24: "Critical low battery",
+    26: "Dustbin blockage",
     40: "Dustbin is blocked",
 }
 

--- a/sharkiq/sharkiq.py
+++ b/sharkiq/sharkiq.py
@@ -10,6 +10,7 @@ from pprint import pformat
 from typing import Any, Dict, Iterable, List, Optional, Set, Union, TYPE_CHECKING
 from .const import DEVICE_URL, EU_DEVICE_URL
 from .exc import SharkIqReadOnlyPropertyError
+from .utils import clean_property_name as _clean_property_name
 
 try:
     import ujson as json
@@ -145,22 +146,6 @@ ERROR_MESSAGES = {
     26: "Dustbin blockage",
     40: "Dustbin is blocked",
 }
-
-
-def _clean_property_name(raw_property_name: str) -> str:
-    """
-    Clean up property names.
-    
-    Args:
-        raw_property_name: The raw property name.
-
-    Returns:
-        The cleaned property name.
-    """
-    if raw_property_name[:4].upper() in ['SET_', 'GET_']:
-        return raw_property_name[4:]
-    else:
-        return raw_property_name
 
 
 class SharkIqVacuum:

--- a/sharkiq/skegox_api.py
+++ b/sharkiq/skegox_api.py
@@ -1,0 +1,387 @@
+"""SharkNinja Skegox cloud API client.
+
+The new SharkNinja backend replaces the legacy Ayla API for migrated devices.
+Uses an IoT shadow model (reported/desired) for state and commands.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import secrets
+import time
+from typing import Any
+
+import aiohttp
+
+from .const import API_TIMEOUT
+from .exc import SkegoxApiError
+
+SKEGOX_CALLER = "ENDUSER_MOBILEAPP"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SkegoxApi:
+    """Async client for the SharkNinja Skegox cloud API.
+
+    Args:
+        auth_manager: A SkegoxAuthManager instance for authentication.
+    """
+
+    def __init__(self, auth_manager: Any) -> None:
+        self._auth = auth_manager
+        self._session: aiohttp.ClientSession | None = None
+        self._property_file_cache: dict[str, tuple[list[dict[str, Any]], float]] = {}
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+        self._property_file_cache.clear()
+
+    def clear_property_file_cache(self, snd: str | None = None) -> None:
+        """Clear cached property file listings."""
+        if snd:
+            self._property_file_cache.pop(snd, None)
+        else:
+            self._property_file_cache.clear()
+
+    async def _get_property_files(self, snd: str) -> list[dict[str, Any]]:
+        """Get property file list with caching (5-minute TTL)."""
+        now = time.time()
+        if snd in self._property_file_cache:
+            cached_files, cached_at = self._property_file_cache[snd]
+            if now - cached_at < 300:
+                return cached_files
+
+        files = await self.list_property_files(snd)
+        self._property_file_cache[snd] = (files, now)
+        return files
+
+    def _headers(self) -> dict[str, str]:
+        """Build request headers with HMAC signature."""
+        now = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        region = self._auth.region
+        return {
+            "Authorization": f"Bearer {self._auth.id_token}",
+            "content-type": "application/json",
+            "x-api-key": region.skegox_api_key,
+            "x-iotn-request-signature": (
+                f"SN-HMAC-SHA256 Credential=x/{now}/*/end-user-api/sn_request, "
+                f"SignedHeaders=host;x-sn-date;x-sn-nonce, "
+                f"Signature={secrets.token_hex(32)}"
+            ),
+            "x-iotn-caller": SKEGOX_CALLER,
+            "x-sn-nonce": secrets.token_hex(16),
+            "x-sn-date": now,
+        }
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> Any:
+        """Make an authenticated request to the Skegox API.
+
+        401 -> Refreshes the Auth0 token and retries once.
+        """
+        session = await self._get_session()
+        region = self._auth.region
+        url = f"{region.skegox_base}{path}"
+        headers = self._headers()
+
+        async with session.request(
+            method,
+            url,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=API_TIMEOUT),
+            **kwargs,
+        ) as resp:
+            if resp.status == 401:
+                _LOGGER.warning("Skegox 401 — refreshing auth and retrying")
+                await self._auth.ensure_authenticated(force_refresh=True)
+                headers = self._headers()
+                async with session.request(
+                    method,
+                    url,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=API_TIMEOUT),
+                    **kwargs,
+                ) as retry_resp:
+                    if retry_resp.status >= 300:
+                        text = await retry_resp.text()
+                        raise SkegoxApiError(f"Skegox error ({retry_resp.status}): {text}")
+                    return await retry_resp.json()
+
+            if resp.status >= 300:
+                text = await resp.text()
+                raise SkegoxApiError(f"Skegox error ({resp.status}): {text}")
+
+            return await resp.json()
+
+    # --- Discovery ---
+
+    async def discover(self) -> None:
+        """Extract user_id from JWT and discover household_id from Skegox API."""
+        token = self._auth.id_token
+        if not token:
+            await self._auth.ensure_authenticated()
+            token = self._auth.id_token
+
+        parts = token.split(".")
+        payload = parts[1] + "=" * (4 - len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+        sub = claims.get("sub", "")
+        user_id = sub.split("|", 1)[1] if "|" in sub else sub
+        self._auth.set_user_id(user_id)
+        _LOGGER.info("Discovered user ID: %s", user_id)
+
+        if not self._auth.household_id:
+            data = await self._request("GET", f"/householdsEndUser?userId={user_id}")
+            households = data.get("households", [])
+            if households:
+                household_id = households[0]
+                self._auth.set_household_id(household_id)
+                _LOGGER.info("Discovered household ID: %s", household_id)
+            else:
+                raise SkegoxApiError(
+                    "No households found for user. "
+                    "Is a Shark device registered on this account?"
+                )
+
+    # --- Device listing ---
+
+    async def list_devices(self) -> list[dict[str, Any]]:
+        """List all devices for the user."""
+        if not self._auth.user_id or not self._auth.household_id:
+            await self.discover()
+
+        path = (
+            f"/devicesEndUserController/{self._auth.household_id}"
+            f"/users/{self._auth.user_id}"
+        )
+        data = await self._request("GET", path)
+        items = data.get("items", data) if isinstance(data, dict) else data
+        return items if isinstance(items, list) else [items]
+
+    async def get_device(self, snd: str) -> dict[str, Any]:
+        """Get full device state including shadow, telemetry, connectivity."""
+        if not self._auth.household_id:
+            raise SkegoxApiError("No household ID set")
+        path = (
+            f"/devicesEndUserController/{self._auth.household_id}"
+            f"/devices/{snd}"
+        )
+        return await self._request("GET", path)
+
+    async def get_all_devices(self) -> list[dict[str, Any]]:
+        """Get full state for all devices."""
+        device_list = await self.list_devices()
+
+        async def _fetch_full(dev: dict[str, Any]) -> dict[str, Any] | None:
+            snd = dev.get("deviceId", dev.get("snd"))
+            if snd:
+                try:
+                    full = await self.get_device(snd)
+                    full["_snd"] = snd
+                    return full
+                except Exception:
+                    _LOGGER.warning(
+                        "Failed to fetch full state for device %s", snd, exc_info=True
+                    )
+                    return None
+            return dev
+
+        results = await asyncio.gather(
+            *[_fetch_full(dev) for dev in device_list], return_exceptions=True
+        )
+        devices: list[dict[str, Any]] = []
+        for result in results:
+            if isinstance(result, Exception):
+                _LOGGER.warning("Device fetch failed: %s", result)
+            elif result is not None:
+                devices.append(result)
+        return devices
+
+    # --- Property files (MARD, maps, etc.) ---
+
+    async def list_property_files(self, snd: str) -> list[dict[str, Any]]:
+        """List all available property files for a device."""
+        if not self._auth.household_id:
+            raise SkegoxApiError("No household ID set")
+        path = (
+            f"/devicesEndUserController/{self._auth.household_id}"
+            f"/devices/{snd}/property-files"
+        )
+        try:
+            wrapper = await self._request("GET", path)
+            files = wrapper.get("files") if isinstance(wrapper, dict) else None
+            return files if isinstance(files, list) else []
+        except Exception:
+            _LOGGER.debug("Skegox property-files list failed for %s", snd, exc_info=True)
+            return []
+
+    async def fetch_property_file(self, snd: str, property_name: str) -> bytes | None:
+        """Fetch a file-type property's content from Skegox."""
+        if not self._auth.household_id:
+            raise SkegoxApiError("No household ID set")
+
+        all_files = await self._get_property_files(snd)
+        if not all_files:
+            _LOGGER.warning("No property files listed for %s", snd)
+            return None
+
+        matching: dict[str, Any] | None = None
+        prefix_match: dict[str, Any] | None = None
+        for file_info in all_files:
+            fname = file_info.get("name", "")
+            if fname == property_name:
+                matching = file_info
+                break
+            if prefix_match is None and fname.startswith(property_name):
+                prefix_match = file_info
+
+        if matching is None:
+            matching = prefix_match
+            if matching:
+                _LOGGER.debug(
+                    "Property file '%s' matched via prefix to '%s' for %s",
+                    property_name,
+                    matching.get("name", ""),
+                    snd,
+                )
+
+        if not matching:
+            _LOGGER.warning(
+                "Property file '%s' not found in file list for %s. Available: %s",
+                property_name,
+                snd,
+                [f.get("name") for f in all_files],
+            )
+            return None
+
+        presigned = (
+            matching.get("presignedUrl")
+            or matching.get("url")
+            or matching.get("downloadUrl")
+        )
+        if not presigned:
+            _LOGGER.warning(
+                "No URL in file entry for %s/%s. Keys: %s",
+                snd,
+                property_name,
+                list(matching.keys()),
+            )
+            return None
+
+        _LOGGER.debug(
+            "Presigned URL for %s/%s: %s...", snd, property_name, presigned[:80]
+        )
+
+        try:
+            session = await self._get_session()
+            async with session.get(
+                presigned, timeout=aiohttp.ClientTimeout(total=API_TIMEOUT)
+            ) as resp:
+                if resp.status >= 300:
+                    body = await resp.text()
+                    _LOGGER.warning(
+                        "Presigned URL fetch for %s/%s returned %d: %s",
+                        snd,
+                        property_name,
+                        resp.status,
+                        body[:500],
+                    )
+                    return None
+                content = await resp.read()
+                _LOGGER.info("Fetched %s/%s: %d bytes", snd, property_name, len(content))
+                return content
+        except Exception:
+            _LOGGER.warning(
+                "Presigned URL fetch failed for %s/%s", snd, property_name, exc_info=True
+            )
+            return None
+
+    # --- Commands (IoT shadow model) ---
+
+    async def set_desired_property(
+        self, snd: str, property_name: str, value: Any
+    ) -> None:
+        """Set a device property via shadow desired state."""
+        if not self._auth.household_id:
+            raise SkegoxApiError("No household ID set")
+        path = (
+            f"/devicesEndUserController/{self._auth.household_id}"
+            f"/devices/{snd}"
+        )
+        payload = {"shadow": {"properties": {"desired": {property_name: value}}}}
+        await self._request("PATCH", path, json=payload)
+        _LOGGER.info("Set %s=%s on %s", property_name, value, snd)
+
+    async def send_command(self, snd: str, command: str) -> None:
+        """Send a vacuum command (start, stop, pause, return, locate)."""
+        command_map = {
+            "start": ("Operating_Mode", 2),
+            "stop": ("Operating_Mode", 0),
+            "pause": ("Operating_Mode", 1),
+            "return_to_base": ("Operating_Mode", 3),
+            "locate": ("Find_Device", 1),
+        }
+        if command not in command_map:
+            _LOGGER.warning("Unknown command: %s", command)
+            return
+        prop, val = command_map[command]
+        await self.set_desired_property(snd, prop, val)
+
+    async def set_fan_speed(self, snd: str, speed: str) -> None:
+        """Set vacuum fan speed (eco, normal, max)."""
+        speed_map = {"eco": 0, "normal": 1, "max": 2}
+        val = speed_map.get(speed.lower())
+        if val is None:
+            _LOGGER.warning("Unknown fan speed: %s", speed)
+            return
+        await self.set_desired_property(snd, "Power_Mode", val)
+
+    async def clean_rooms(
+        self,
+        snd: str,
+        rooms: list[str],
+        floor_id: str,
+        clean_type: str = "dry",
+        clean_count: int = 1,
+        mode: str = "UserRoom",
+        use_v3: bool = False,
+    ) -> None:
+        """Start cleaning specific rooms."""
+        if use_v3:
+            areas_payload = json.dumps(
+                {
+                    "areas_to_clean": {mode: rooms},
+                    "clean_count": clean_count,
+                    "floor_id": floor_id,
+                    "cleantype": clean_type,
+                }
+            )
+            await self.set_desired_property(snd, "AreasToClean_V3", areas_payload)
+        else:
+            areas_payload = json.dumps(
+                {
+                    "floor_id": floor_id,
+                    "areas_to_clean": [f"{mode}:{room}" for room in rooms],
+                    "clean_count": clean_count,
+                }
+            )
+            await self.set_desired_property(snd, "Areas_To_Clean", areas_payload)
+            await self.set_desired_property(snd, "Operating_Mode", 2)
+        _LOGGER.info(
+            "Clean rooms %s on %s (mode=%s, count=%d, v3=%s)",
+            rooms,
+            snd,
+            mode,
+            clean_count,
+            use_v3,
+        )

--- a/sharkiq/skegox_auth.py
+++ b/sharkiq/skegox_auth.py
@@ -1,0 +1,318 @@
+"""Auth0 authentication manager for the Skegox API.
+
+Handles Auth0 password grant and refresh_token grant — no browser required.
+Tokens are persisted via an optional callback for integration with external
+storage (e.g., Home Assistant config entries).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+import aiohttp
+
+from .const import REGION_CONFIGS, RegionConfig, REGION_ELSEWHERE
+from .exc import SkegoxAuthError, SkegoxAuthLockedError, SkegoxAuthRequiresVerificationError
+
+AUTH0_SCOPES = "openid email profile offline_access"
+
+AYLA_REFRESH_BUFFER = timedelta(minutes=5)
+
+_LOGGER = logging.getLogger(__name__)
+
+@dataclass
+class AuthTokens:
+    """Holds all authentication tokens for a session."""
+
+    auth0_id_token: str | None = None
+    auth0_refresh_token: str | None = None
+    auth0_access_token: str | None = None
+    auth0_expiry: datetime | None = None
+    ayla_access_token: str | None = None
+    ayla_refresh_token: str | None = None
+    ayla_expiry: datetime | None = None
+    household_id: str | None = None
+    user_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize tokens to a dict for external storage."""
+        return {
+            "auth0_id_token": self.auth0_id_token,
+            "auth0_refresh_token": self.auth0_refresh_token,
+            "auth0_access_token": self.auth0_access_token,
+            "auth0_expiry": self.auth0_expiry.isoformat() if self.auth0_expiry else None,
+            "ayla_access_token": self.ayla_access_token,
+            "ayla_refresh_token": self.ayla_refresh_token,
+            "ayla_expiry": self.ayla_expiry.isoformat() if self.ayla_expiry else None,
+            "household_id": self.household_id,
+            "user_id": self.user_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AuthTokens:
+        """Deserialize tokens from external storage."""
+        tokens = cls()
+        tokens.auth0_id_token = data.get("auth0_id_token")
+        tokens.auth0_refresh_token = data.get("auth0_refresh_token")
+        tokens.auth0_access_token = data.get("auth0_access_token")
+        if expiry_str := data.get("auth0_expiry"):
+            try:
+                tokens.auth0_expiry = datetime.fromisoformat(expiry_str)
+            except (ValueError, TypeError):
+                pass
+        tokens.ayla_access_token = data.get("ayla_access_token")
+        tokens.ayla_refresh_token = data.get("ayla_refresh_token")
+        if expiry_str := data.get("ayla_expiry"):
+            try:
+                tokens.ayla_expiry = datetime.fromisoformat(expiry_str)
+            except (ValueError, TypeError):
+                pass
+        tokens.household_id = data.get("household_id")
+        tokens.user_id = data.get("user_id")
+        return tokens
+
+    @property
+    def auth0_token_valid(self) -> bool:
+        """Check if the Auth0 id_token is still valid."""
+        if not self.auth0_id_token or not self.auth0_expiry:
+            return False
+        return datetime.now(timezone.utc) < self.auth0_expiry
+
+    @property
+    def ayla_token_expiring_soon(self) -> bool:
+        """Check if the Ayla access token is expiring soon."""
+        if not self.ayla_access_token or not self.ayla_expiry:
+            return True
+        return datetime.now(timezone.utc) >= self.ayla_expiry - AYLA_REFRESH_BUFFER
+
+
+class SkegoxAuthManager:
+    """Manages Auth0 authentication lifecycle for the Skegox API.
+
+    Auth cascade (no browser):
+        1. Load cached tokens from token_store
+        2. If id_token is valid, use it
+        3. Try Auth0 refresh_token grant
+        4. Try Auth0 password grant
+        5. Raise SkegoxAuthError (triggers reauth flow in consumer)
+
+    Args:
+        username: Auth0 username (email).
+        password: Auth0 password.
+        region: Region key ("elsewhere" or "europe").
+        token_store: Initial token dict (e.g., from persistent storage).
+        on_tokens_changed: Callback invoked whenever tokens are updated.
+            Receives the serialized token dict.
+    """
+
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        region: str = REGION_ELSEWHERE,
+        token_store: dict[str, Any] | None = None,
+        on_tokens_changed: Callable[[dict[str, Any]], None] | None = None,
+    ) -> None:
+        self._username = username
+        self._password = password
+        self._region_config = REGION_CONFIGS[region]
+        self._tokens = AuthTokens.from_dict(token_store) if token_store else AuthTokens()
+        self._on_tokens_changed = on_tokens_changed
+        self._session: aiohttp.ClientSession | None = None
+
+    @property
+    def region(self) -> RegionConfig:
+        return self._region_config
+
+    @property
+    def id_token(self) -> str | None:
+        return self._tokens.auth0_id_token
+
+    @property
+    def ayla_access_token(self) -> str | None:
+        return self._tokens.ayla_access_token
+
+    @property
+    def ayla_refresh_token(self) -> str | None:
+        return self._tokens.ayla_refresh_token
+
+    @property
+    def household_id(self) -> str | None:
+        return self._tokens.household_id
+
+    @property
+    def user_id(self) -> str | None:
+        return self._tokens.user_id
+
+    @property
+    def tokens(self) -> AuthTokens:
+        return self._tokens
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    def _save_tokens(self) -> None:
+        if self._on_tokens_changed is not None:
+            self._on_tokens_changed(self._tokens.to_dict())
+
+    async def ensure_authenticated(self, force_refresh: bool = False) -> str:
+        """Return a valid Auth0 id_token, refreshing if needed.
+
+        Raises:
+            SkegoxAuthError: If all authentication methods fail.
+            SkegoxAuthRequiresVerificationError: If MFA/CAPTCHA is required.
+        """
+        if not force_refresh and self._tokens.auth0_token_valid:
+            _LOGGER.debug("Using cached Auth0 id_token")
+            assert self._tokens.auth0_id_token is not None
+            return self._tokens.auth0_id_token
+
+        if self._tokens.auth0_refresh_token:
+            try:
+                await self._refresh_auth0_token()
+                _LOGGER.debug("Auth0 token refreshed via refresh_token grant")
+                assert self._tokens.auth0_id_token is not None
+                return self._tokens.auth0_id_token
+            except SkegoxAuthError:
+                _LOGGER.warning("Auth0 refresh_token grant failed")
+
+        try:
+            await self._password_grant_sign_in()
+            _LOGGER.debug("Auth0 password grant successful")
+            assert self._tokens.auth0_id_token is not None
+            return self._tokens.auth0_id_token
+        except SkegoxAuthRequiresVerificationError:
+            raise
+        except SkegoxAuthError:
+            _LOGGER.warning("Auth0 password grant failed")
+
+        raise SkegoxAuthError(
+            "All authentication methods failed. Please re-authenticate."
+        )
+
+    async def _password_grant_sign_in(self) -> None:
+        """Authenticate via Auth0 password grant (no browser)."""
+        payload = {
+            "grant_type": "password",
+            "client_id": self._region_config.auth0_client_id,
+            "username": self._username,
+            "password": self._password,
+            "scope": AUTH0_SCOPES,
+        }
+
+        session = await self._get_session()
+        async with session.post(
+            self._region_config.auth0_token_url,
+            json=payload,
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as resp:
+            data = await resp.json()
+
+            if resp.status == 401:
+                error = data.get("error", "unknown")
+                desc = data.get("error_description", "")
+                if error == "requires_verification":
+                    raise SkegoxAuthRequiresVerificationError(
+                        f"Auth0 requires additional verification: {desc}. "
+                        "Try completing login in the SharkClean app, then retry."
+                    )
+                raise SkegoxAuthError(f"Auth0 password grant failed (401): {desc}")
+
+            if resp.status >= 400:
+                error = data.get("error", "unknown")
+                desc = data.get("error_description", "")
+                if resp.status == 429:
+                    raise SkegoxAuthLockedError(f"Auth0 rate limited: {error} {desc}")
+                raise SkegoxAuthError(
+                    f"Auth0 password grant failed ({resp.status}): {error} {desc}"
+                )
+
+            if "id_token" not in data:
+                raise SkegoxAuthError(
+                    "Auth0 response missing id_token. "
+                    "The password grant may not be enabled for this account."
+                )
+
+            self._tokens.auth0_id_token = data["id_token"]
+            self._tokens.auth0_access_token = data.get("access_token")
+            self._tokens.auth0_refresh_token = data.get("refresh_token")
+            self._tokens.auth0_expiry = self._decode_jwt_expiry(data["id_token"])
+            self._save_tokens()
+
+    async def _refresh_auth0_token(self) -> None:
+        """Exchange Auth0 refresh_token for a new id_token."""
+        if not self._tokens.auth0_refresh_token:
+            raise SkegoxAuthError("No Auth0 refresh token available")
+
+        payload = {
+            "grant_type": "refresh_token",
+            "client_id": self._region_config.auth0_client_id,
+            "refresh_token": self._tokens.auth0_refresh_token,
+        }
+
+        session = await self._get_session()
+        async with session.post(
+            self._region_config.auth0_token_url,
+            json=payload,
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as resp:
+            data = await resp.json()
+
+            if resp.status != 200:
+                error = data.get("error", "unknown")
+                desc = data.get("error_description", "")
+                if resp.status == 429:
+                    raise SkegoxAuthLockedError(f"Auth0 rate limited: {error} {desc}")
+                raise SkegoxAuthError(
+                    f"Auth0 refresh failed ({resp.status}): {error} {desc}"
+                )
+
+            self._tokens.auth0_id_token = data["id_token"]
+            self._tokens.auth0_access_token = data.get("access_token")
+            if "refresh_token" in data:
+                self._tokens.auth0_refresh_token = data["refresh_token"]
+            self._tokens.auth0_expiry = self._decode_jwt_expiry(data["id_token"])
+            self._save_tokens()
+
+    def update_ayla_tokens(
+        self, access_token: str, refresh_token: str, expiry: datetime
+    ) -> None:
+        """Called after Ayla token_sign_in to persist Ayla tokens."""
+        self._tokens.ayla_access_token = access_token
+        self._tokens.ayla_refresh_token = refresh_token
+        self._tokens.ayla_expiry = expiry
+        self._save_tokens()
+
+    def set_household_id(self, household_id: str) -> None:
+        self._tokens.household_id = household_id
+        self._save_tokens()
+
+    def set_user_id(self, user_id: str) -> None:
+        self._tokens.user_id = user_id
+        self._save_tokens()
+
+    @staticmethod
+    def _decode_jwt_expiry(token: str) -> datetime:
+        """Extract the exp claim from a JWT and return as datetime."""
+        try:
+            parts = token.split(".")
+            payload = parts[1] + "=" * (4 - len(parts[1]) % 4)
+            claims = json.loads(base64.urlsafe_b64decode(payload))
+            exp = claims.get("exp")
+            if exp:
+                return datetime.fromtimestamp(exp, tz=timezone.utc)
+        except Exception:
+            _LOGGER.debug("Failed to decode JWT expiry", exc_info=True)
+        return datetime.now(timezone.utc) + timedelta(hours=24)

--- a/sharkiq/skegox_auth.py
+++ b/sharkiq/skegox_auth.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
 
@@ -62,14 +62,20 @@ class AuthTokens:
         tokens.auth0_access_token = data.get("auth0_access_token")
         if expiry_str := data.get("auth0_expiry"):
             try:
-                tokens.auth0_expiry = datetime.fromisoformat(expiry_str)
+                dt = datetime.fromisoformat(expiry_str)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                tokens.auth0_expiry = dt
             except (ValueError, TypeError):
                 pass
         tokens.ayla_access_token = data.get("ayla_access_token")
         tokens.ayla_refresh_token = data.get("ayla_refresh_token")
         if expiry_str := data.get("ayla_expiry"):
             try:
-                tokens.ayla_expiry = datetime.fromisoformat(expiry_str)
+                dt = datetime.fromisoformat(expiry_str)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                tokens.ayla_expiry = dt
             except (ValueError, TypeError):
                 pass
         tokens.household_id = data.get("household_id")
@@ -120,6 +126,10 @@ class SkegoxAuthManager:
     ) -> None:
         self._username = username
         self._password = password
+        if region not in REGION_CONFIGS:
+            raise SkegoxAuthError(
+                f"Unknown region '{region}'. Valid regions: {list(REGION_CONFIGS.keys())}"
+            )
         self._region_config = REGION_CONFIGS[region]
         self._tokens = AuthTokens.from_dict(token_store) if token_store else AuthTokens()
         self._on_tokens_changed = on_tokens_changed

--- a/sharkiq/skegox_device.py
+++ b/sharkiq/skegox_device.py
@@ -1,0 +1,862 @@
+"""Device model for Shark vacuums via the Skegox API.
+
+Implements the same interface as the legacy SharkIqVacuum class so that
+consumer code works unchanged regardless of backend.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import struct
+from typing import TYPE_CHECKING, Any
+
+from .sharkiq import ERROR_MESSAGES
+
+if TYPE_CHECKING:
+    from .skegox_api import SkegoxApi
+
+try:
+    from PIL import Image
+
+    _HAS_PIL = True
+except ImportError:
+    _HAS_PIL = False
+
+_LOGGER = logging.getLogger(__name__)
+
+_COORD_SCALE = 50.0 / 3.0
+_COORD_X_OFFSET = 134.5
+_COORD_Y_OFFSET = 203.5
+
+PROP_OPERATING_MODE = "GET_Operating_Mode"
+PROP_CHARGING_STATUS = "GET_Charging_Status"
+PROP_BATTERY_CAPACITY = "GET_Battery_Capacity"
+PROP_ERROR_CODE = "GET_Error_Code"
+PROP_POWER_MODE = "GET_Power_Mode"
+PROP_RSSI = "GET_RSSI"
+PROP_ROBOT_ROOM_LIST = "GET_Robot_Room_List"
+PROP_LOW_LIGHT_MISSION = "GET_LowLightMission"
+PROP_RECHARGE_RESUME = "GET_Recharge_Resume"
+PROP_RECHARGING_TO_RESUME = "GET_Recharging_To_Resume"
+PROP_ROBOT_FIRMWARE_VERSION = "GET_Robot_Firmware_Version"
+PROP_DEVICE_MODEL_NUMBER = "GET_Device_Model_Number"
+
+SET_OPERATING_MODE = "Operating_Mode"
+SET_POWER_MODE = "Power_Mode"
+SET_FIND_DEVICE = "Find_Device"
+SET_AREAS_TO_CLEAN = "Areas_To_Clean"
+SET_AREAS_TO_CLEAN_V3 = "AreasToClean_V3"
+
+OP_MODE_STOP = 0
+OP_MODE_PAUSE = 1
+OP_MODE_START = 2
+OP_MODE_RETURN = 3
+
+POWER_ECO = 1
+POWER_NORMAL = 0
+POWER_MAX = 2
+
+AYLA_TO_SKEGOX_POWER = {POWER_ECO: 0, POWER_NORMAL: 1, POWER_MAX: 2}
+SKEGOX_TO_AYLA_POWER = {v: k for k, v in AYLA_TO_SKEGOX_POWER.items()}
+
+class SkegoxDevice:
+    """Represents a Shark vacuum via the Skegox API.
+
+    Implements the same public interface as SharkIqVacuum.
+    """
+
+    @staticmethod
+    def extract_snd(registry: dict[str, Any]) -> str:
+        """Extract device SND (serial number) from registry data."""
+        bsn = registry.get("Battery_Serial_Num", "")
+        return bsn.split("-")[-1] if "-" in bsn else bsn
+
+    @staticmethod
+    def _merge_properties(
+        target: dict[str, Any], source: dict[str, Any], prefix: str = ""
+    ) -> None:
+        """Merge source properties into target with optional prefix."""
+        for key, value in source.items():
+            prop_key = f"{prefix}{key}"
+            if isinstance(value, dict):
+                target[prop_key] = value
+            else:
+                target[prop_key] = {"value": value}
+
+    def __init__(self, api: SkegoxApi, device_data: dict[str, Any]) -> None:
+        self._api = api
+        self._raw = device_data
+
+        metadata = device_data.get("metadata", {})
+        registry = device_data.get("registry", {})
+        telemetry = device_data.get("telemetry", {})
+        connectivity = device_data.get("connectivityStatus", {})
+        shadow = device_data.get("shadow", {})
+        reported = shadow.get("properties", {}).get("reported", {})
+
+        self._snd = device_data.get("_snd", "")
+        if not self._snd:
+            self._snd = SkegoxDevice.extract_snd(registry)
+        self._dsn = self._snd
+
+        self._name = metadata.get("deviceName", "Shark Robot")
+        self._oem_model = registry.get("Device_Serial_Num", "")
+        self._model_number = registry.get("Device_Model_Number", "")
+        self._connection_status = (
+            "Online" if connectivity.get("connected") else "Offline"
+        )
+
+        self.properties_full: dict[str, Any] = {}
+        self._merge_properties(self.properties_full, telemetry, prefix="GET_")
+        self._merge_properties(self.properties_full, reported, prefix="GET_")
+
+        fw = registry.get("FW_VERSION", "")
+        if fw:
+            self.properties_full[PROP_ROBOT_FIRMWARE_VERSION] = {"value": fw}
+
+        model = registry.get("Device_Model_Number", "")
+        if model:
+            self.properties_full[PROP_DEVICE_MODEL_NUMBER] = {"value": model}
+
+        self._floor_id: str = ""
+        self._rooms: list[str] = []
+        self._room_name_map: dict[str, str] = {}
+        self._mard_raw: dict[str, Any] | None = None
+        self._room_polygons: dict[str, list[tuple[float, float]]] = {}
+        self._no_go_zones: list[dict[str, Any]] = []
+        self._parse_room_list(reported)
+
+        self._floor_plan_raw: bytes | None = None
+        self._floor_plan_image: Any = None
+        self._floor_plan_edges: list[tuple[tuple[float, float], tuple[float, float]]] = []
+        self._floor_plan_doors: list[tuple[tuple[float, float], tuple[float, float]]] = []
+        self._floor_plan_scale: float = 0.06
+        self._floor_plan_origin: tuple[float, float] = (0.0, 0.0)
+        self._floor_plan_dims: tuple[int, int] = (0, 0)
+
+        self._has_areas_v3 = "AreasToClean_V3" in reported
+
+    @property
+    def serial_number(self) -> str:
+        return self._dsn
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def oem_model_number(self) -> str:
+        return self._oem_model
+
+    @property
+    def vac_model_number(self) -> str | None:
+        model = self.get_property_value(PROP_DEVICE_MODEL_NUMBER)
+        return str(model) if model else None
+
+    @property
+    def error_code(self) -> int | None:
+        return self.get_property_value(PROP_ERROR_CODE)
+
+    @property
+    def error_text(self) -> str | None:
+        err = self.error_code
+        if err:
+            return ERROR_MESSAGES.get(err, f"Unknown error ({err})")
+        return None
+
+    def get_property_value(self, property_name: str | Any) -> Any:
+        """Get the value of a property."""
+        name = property_name.value if hasattr(property_name, "value") else property_name
+        prop = self.properties_full.get(name)
+        if prop is None and not name.startswith("GET_"):
+            prop = self.properties_full.get(f"GET_{name}")
+        if prop is None:
+            return None
+        if isinstance(prop, dict):
+            value = prop.get("value")
+        else:
+            value = prop
+        if name in (PROP_POWER_MODE, "Power_Mode", "GET_Power_Mode") and value in SKEGOX_TO_AYLA_POWER:
+            return SKEGOX_TO_AYLA_POWER[value]
+        return value
+
+    async def async_set_property_value(self, property_name: str | Any, value: Any) -> None:
+        """Set a property value via the Skegox API."""
+        name = property_name.value if hasattr(property_name, "value") else property_name
+        if name.startswith("GET_"):
+            name = name[4:]
+        if hasattr(value, "value"):
+            value = value.value
+        if name == "Power_Mode" and value in AYLA_TO_SKEGOX_POWER:
+            value = AYLA_TO_SKEGOX_POWER[value]
+        await self._api.set_desired_property(self._snd, name, value)
+
+    async def async_set_operating_mode(self, mode: Any) -> None:
+        """Set the operating mode."""
+        mode_val = mode.value if hasattr(mode, "value") else mode
+        await self._api.set_desired_property(self._snd, SET_OPERATING_MODE, mode_val)
+
+    async def async_find_device(self) -> None:
+        """Make the device emit a chirp."""
+        await self._api.set_desired_property(self._snd, SET_FIND_DEVICE, 1)
+
+    async def async_clean_rooms(self, rooms: list[str]) -> None:
+        """Clean specific rooms."""
+        await self._api.clean_rooms(
+            snd=self._snd, rooms=rooms, floor_id=self._floor_id, use_v3=self._has_areas_v3
+        )
+
+    def _parse_room_list(self, reported: dict[str, Any]) -> None:
+        """Parse room list from Robot_Room_List or AreasToClean_V3 property."""
+        room_list_raw = reported.get("Robot_Room_List", {})
+        room_list_val = (
+            room_list_raw.get("value", room_list_raw)
+            if isinstance(room_list_raw, dict)
+            else room_list_raw
+        )
+        if room_list_val and isinstance(room_list_val, str) and ":" in room_list_val:
+            parts = room_list_val.split(":")
+            self._floor_id = parts[0]
+            self._rooms = parts[1:]
+            return
+
+        for prop_name in ("AreasToClean_V3", "AreasToClean_V2", "Areas_To_Clean"):
+            floor_id, rooms = self._parse_areas_json(prop_name, reported)
+            if rooms:
+                self._floor_id = floor_id
+                self._rooms = rooms
+                return
+
+    def _parse_areas_json(
+        self, prop_name: str, reported: dict[str, Any]
+    ) -> tuple[str | None, list[str] | None]:
+        """Try to parse areas data from a property."""
+        prop_data = reported.get(prop_name, {})
+        prop_val = (
+            prop_data.get("value", prop_data) if isinstance(prop_data, dict) else prop_data
+        )
+        if not prop_val:
+            return None, None
+
+        try:
+            parsed = json.loads(prop_val) if isinstance(prop_val, str) else prop_val
+            if not isinstance(parsed, dict):
+                return None, None
+
+            floor_id = parsed.get("floor_id", "")
+            areas = parsed.get("areas_to_clean", {})
+
+            if isinstance(areas, dict):
+                all_rooms = []
+                for room_list in areas.values():
+                    if isinstance(room_list, list):
+                        all_rooms.extend(room_list)
+                if all_rooms:
+                    return floor_id, all_rooms
+            elif isinstance(areas, list):
+                rooms = [
+                    item.split(":", 1)[-1] if ":" in item else item for item in areas
+                ]
+                return floor_id, rooms
+        except (ValueError, TypeError):
+            pass
+
+        return None, None
+
+    def parse_floor_plan(self, data: bytes) -> None:
+        """Parse floorRPfile1 protobuf data into an image and edge/door segments."""
+        self._floor_plan_raw = data
+        try:
+            self._parse_floor_plan_protobuf(data)
+        except Exception:
+            _LOGGER.debug(
+                "Floor plan parse failed for %s", self._name, exc_info=True
+            )
+
+    def _parse_floor_plan_protobuf(self, data: bytes) -> None:
+        """Parse floorRPfile1 protobuf structure."""
+        cp = 0
+
+        field_data: dict[int, bytes] = {}
+        field_varints: dict[int, int] = {}
+        field_floats: dict[int, float] = {}
+        field_28_entries: list[bytes] = []
+
+        while cp < len(data):
+            tag, cp = _read_varint(data, cp)
+            fn = tag >> 3
+            wt = tag & 7
+
+            if wt == 2:
+                length, cp = _read_varint(data, cp)
+                if fn == 28:
+                    field_28_entries.append(data[cp : cp + length])
+                else:
+                    field_data[fn] = data[cp : cp + length]
+                cp += length
+            elif wt == 0:
+                val, cp = _read_varint(data, cp)
+                field_varints[fn] = val
+            elif wt == 5:
+                val = struct.unpack("<f", data[cp : cp + 4])[0]
+                cp += 4
+                field_floats[fn] = val
+            else:
+                break
+
+        img_raw = field_data.get(21) or field_data.get(5)
+        if img_raw:
+            self._parse_floor_image(img_raw)
+
+        for entry in field_28_entries:
+            self._parse_floor_edge_entry(entry)
+
+    def _parse_floor_image(self, data: bytes) -> None:
+        """Parse image container from field 5/21."""
+        if not _HAS_PIL:
+            _LOGGER.debug("PIL not available; skipping floor plan image parsing")
+            return
+
+        cp = 0
+        scale = 0.06
+        origin_x = 0.0
+        origin_y = 0.0
+        width = 0
+        height = 0
+        pixel_data: bytes = b""
+
+        while cp < len(data):
+            tag, cp = _read_varint(data, cp)
+            fn = tag >> 3
+            wt = tag & 7
+
+            if wt == 5:
+                val = struct.unpack("<f", data[cp : cp + 4])[0]
+                cp += 4
+                if fn == 1:
+                    scale = val
+            elif wt == 2:
+                length, cp = _read_varint(data, cp)
+                fd = data[cp : cp + length]
+                cp += length
+                if fn == 2:
+                    if len(fd) >= 10:
+                        origin_x = struct.unpack("<f", fd[1:5])[0]
+                        origin_y = struct.unpack("<f", fd[6:10])[0]
+                elif fn == 6:
+                    pixel_data = fd
+            elif wt == 0:
+                val, cp = _read_varint(data, cp)
+                if fn == 3:
+                    width = val
+                elif fn == 4:
+                    height = val
+            else:
+                break
+
+        if not pixel_data or width == 0 or height == 0:
+            return
+
+        self._floor_plan_scale = scale
+        self._floor_plan_origin = (origin_x, origin_y)
+        self._floor_plan_dims = (width, height)
+
+        palette = self._parse_palette()
+
+        img = Image.new("RGBA", (width, height))
+        pixels = img.load()
+        for py in range(height):
+            for px in range(width):
+                idx = py * width + px
+                if idx < len(pixel_data):
+                    color_idx = pixel_data[idx]
+                    if palette and color_idx < len(palette):
+                        r, g, b = palette[color_idx]
+                        pixels[px, py] = (r, g, b, 255)
+                    else:
+                        gray = min(255, color_idx * 2)
+                        pixels[px, py] = (gray, gray, gray, 255)
+                else:
+                    pixels[px, py] = (0, 0, 0, 0)
+        self._floor_plan_image = img
+        _LOGGER.info(
+            "Floor plan image loaded for %s: %dx%d, scale=%.2fm/px, palette=%d colors",
+            self._name,
+            width,
+            height,
+            scale,
+            len(palette),
+        )
+
+    def _parse_palette(self) -> list[tuple[int, int, int]]:
+        """Parse palette from field 10."""
+        field_10_raw: bytes | None = None
+
+        if self._floor_plan_raw is None:
+            return []
+
+        data = self._floor_plan_raw
+        cp = 0
+        while cp < len(data):
+            tag, cp = _read_varint(data, cp)
+            fn = tag >> 3
+            wt = tag & 7
+            if wt == 2:
+                length, cp = _read_varint(data, cp)
+                if fn == 10:
+                    field_10_raw = data[cp : cp + length]
+                    break
+                cp += length
+            elif wt == 0:
+                _, cp = _read_varint(data, cp)
+            elif wt == 5:
+                cp += 4
+            else:
+                break
+
+        if not field_10_raw:
+            return []
+
+        cp = 0
+        palette_count = 256
+        palette_data: bytes = b""
+
+        while cp < len(field_10_raw):
+            tag, cp = _read_varint(field_10_raw, cp)
+            fn = tag >> 3
+            wt = tag & 7
+            if wt == 0:
+                val, cp = _read_varint(field_10_raw, cp)
+                if fn == 2:
+                    palette_count = val
+            elif wt == 2:
+                length, cp = _read_varint(field_10_raw, cp)
+                if fn == 3:
+                    palette_data = field_10_raw[cp : cp + length]
+                cp += length
+            elif wt == 5:
+                cp += 4
+            else:
+                break
+
+        palette: list[tuple[int, int, int]] = [(0, 0, 0)] * palette_count
+
+        cp = 0
+        idx = 0
+        while cp < len(palette_data) and idx < palette_count:
+            tag, cp = _read_varint(palette_data, cp)
+            fn = tag >> 3
+            wt = tag & 7
+            if wt == 2:
+                length, cp = _read_varint(palette_data, cp)
+                fd = palette_data[cp : cp + length]
+                cp += length
+                if length == 3:
+                    palette[idx] = (fd[0], fd[1], fd[2])
+                    idx += 1
+                elif length >= 3:
+                    pp = 0
+                    while pp < len(fd) and idx < palette_count:
+                        if pp + 3 < len(fd):
+                            r = fd[pp]
+                            g = fd[pp + 1]
+                            b = fd[pp + 2]
+                            palette[idx] = (r, g, b)
+                            idx += 1
+                            pp += 3
+                        else:
+                            break
+            elif wt == 0:
+                _, cp = _read_varint(palette_data, cp)
+            elif wt == 5:
+                cp += 4
+            else:
+                break
+
+        return palette
+
+    def _parse_floor_edge_entry(self, entry: bytes) -> None:
+        """Parse a single edge/door entry from field 28."""
+        ep = 0
+        edge_type = ""
+        points: list[tuple[float, float]] = []
+
+        while ep < len(entry):
+            tag2, ep = _read_varint(entry, ep)
+            fn2 = tag2 >> 3
+            wt2 = tag2 & 7
+
+            if wt2 == 2:
+                length2, ep = _read_varint(entry, ep)
+                fd = entry[ep : ep + length2]
+                ep += length2
+
+                if fn2 == 2:
+                    edge_type = fd.decode("utf-8", errors="replace")
+                elif fn2 == 4:
+                    pp = 0
+                    while pp < len(fd):
+                        ptag, pp = _read_varint(fd, pp)
+                        pfn = ptag >> 3
+                        pwt = ptag & 7
+                        if pwt == 2:
+                            plen, pp = _read_varint(fd, pp)
+                            pdata = fd[pp : pp + plen]
+                            pp += plen
+                            if len(pdata) >= 10:
+                                x = struct.unpack("<f", pdata[1:5])[0]
+                                y = struct.unpack("<f", pdata[6:10])[0]
+                                points.append((x * 100, y * 100))
+                        elif pwt == 0:
+                            _, pp = _read_varint(fd, pp)
+                        else:
+                            break
+            elif wt2 == 0:
+                _, ep = _read_varint(entry, ep)
+            else:
+                break
+
+        if len(points) >= 2:
+            if edge_type == "door":
+                self._floor_plan_doors.append((points[0], points[1]))
+            elif edge_type == "edge":
+                for i in range(len(points) - 1):
+                    self._floor_plan_edges.append((points[i], points[i + 1]))
+
+    def load_mard(self, mard_body: bytes) -> None:
+        """Parse MARD data and populate rooms."""
+        try:
+            parsed = json.loads(mard_body.decode("utf-8"))
+            self._load_mard_json(parsed)
+            return
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            pass
+
+        try:
+            decoded = base64.b64decode(mard_body)
+            self._load_mard_protobuf(decoded)
+            return
+        except Exception:
+            _LOGGER.debug("MARD for %s: not valid JSON or base64 protobuf", self._name)
+
+    def _load_mard_json(self, parsed: dict[str, Any]) -> None:
+        """Parse MARD JSON format."""
+        if not self._mard_raw:
+            _LOGGER.debug(
+                "MARD full structure for %s: %s",
+                self._name,
+                json.dumps(parsed, indent=2)[:2000],
+            )
+
+        self._mard_raw = parsed
+
+        name_map: dict[str, str] = {}
+        rooms: list[str] = []
+        room_polygons: dict[str, list[tuple[float, float]]] = {}
+        no_go_zones: list[dict[str, Any]] = []
+
+        for area in parsed.get("areas", []):
+            meta = area.get("area_meta_data", "")
+            points_raw = area.get("points", [])
+            points = [
+                (p["x"], p["y"]) for p in points_raw if "x" in p and "y" in p
+            ]
+
+            if meta.startswith("UserRoom:"):
+                robot_name = area.get("robot_room_name", "") or ""
+                user_name = area.get("user_room_name", "") or ""
+                if not robot_name:
+                    continue
+                display_name = user_name or robot_name
+                name_map[robot_name] = display_name
+                rooms.append(display_name)
+                if points:
+                    room_polygons[display_name] = points
+
+            elif meta.startswith("UserNoGo:"):
+                uuid_val = meta.split(":", 1)[1] if ":" in meta else ""
+                area_state = area.get("area_state", "blocking")
+                if points:
+                    no_go_zones.append(
+                        {
+                            "uuid": uuid_val,
+                            "points": points,
+                            "area_state": area_state,
+                        }
+                    )
+
+        mard_floor_id = parsed.get("floor_id")
+        if isinstance(mard_floor_id, str) and mard_floor_id:
+            self._floor_id = mard_floor_id
+
+        if rooms:
+            self._rooms = rooms
+            self._room_name_map = name_map
+            self._room_polygons = room_polygons
+            _LOGGER.info("MARD rooms for %s: %s", self._name, rooms)
+        else:
+            _LOGGER.debug("MARD for %s: no rooms found", self._name)
+
+        if no_go_zones:
+            self._no_go_zones = no_go_zones
+            _LOGGER.info(
+                "MARD no-go zones for %s: %d", self._name, len(no_go_zones)
+            )
+
+    def _load_mard_protobuf(self, data: bytes) -> None:
+        """Parse base64-decoded protobuf zones data."""
+        pos = 0
+        tag, pos = _read_varint(data, pos)
+        if (tag >> 3) != 6:
+            _LOGGER.debug("Protobuf MARD: expected field 6, got %d", tag >> 3)
+            return
+
+        length, pos = _read_varint(data, pos)
+        container = data[pos : pos + length]
+
+        name_map: dict[str, str] = {}
+        rooms: list[str] = []
+        room_polygons: dict[str, list[tuple[float, float]]] = {}
+        no_go_zones: list[dict[str, Any]] = []
+
+        cp = 0
+        while cp < len(container):
+            tag, cp = _read_varint(container, cp)
+            fn = tag >> 3
+            wt = tag & 7
+
+            if wt != 2:
+                if wt == 0:
+                    _, cp = _read_varint(container, cp)
+                continue
+
+            field_len, cp = _read_varint(container, cp)
+            field_data = container[cp : cp + field_len]
+            cp += field_len
+
+            if fn == 3:
+                self._floor_id = field_data.decode("utf-8")
+
+            elif fn == 15:
+                room_name, points = _parse_room_protobuf(field_data)
+                if room_name and points:
+                    name_map[room_name] = room_name
+                    rooms.append(room_name)
+                    room_polygons[room_name] = points
+
+            elif fn == 16:
+                uuid_val, zone_points, zone_type = _parse_nogo_protobuf(field_data)
+                if zone_points:
+                    no_go_zones.append(
+                        {
+                            "uuid": uuid_val,
+                            "points": zone_points,
+                            "area_state": "blocking",
+                        }
+                    )
+
+        if rooms:
+            self._rooms = rooms
+            self._room_name_map = name_map
+            self._room_polygons = room_polygons
+            self._mard_raw = {"floor_id": self._floor_id, "areas": []}
+            _LOGGER.info("MARD rooms for %s: %s", self._name, rooms)
+        else:
+            _LOGGER.debug("MARD protobuf for %s: no rooms found", self._name)
+
+        if no_go_zones:
+            self._no_go_zones = no_go_zones
+            _LOGGER.info(
+                "MARD no-go zones for %s: %d", self._name, len(no_go_zones)
+            )
+
+    @property
+    def floor_id(self) -> str:
+        return self._floor_id
+
+    @property
+    def rooms(self) -> list[str]:
+        return self._rooms
+
+    @property
+    def room_name_map(self) -> dict[str, str]:
+        return self._room_name_map
+
+    @property
+    def mard_data(self) -> dict[str, Any] | None:
+        return self._mard_raw
+
+    @property
+    def has_areas_v3(self) -> bool:
+        return self._has_areas_v3
+
+    @property
+    def room_polygons(self) -> dict[str, list[tuple[float, float]]]:
+        return self._room_polygons
+
+    @property
+    def no_go_zones(self) -> list[dict[str, Any]]:
+        return self._no_go_zones
+
+    @property
+    def floor_plan_image(self) -> Any:
+        return self._floor_plan_image
+
+    @property
+    def floor_plan_edges(
+        self,
+    ) -> list[tuple[tuple[float, float], tuple[float, float]]]:
+        return self._floor_plan_edges
+
+    @property
+    def floor_plan_doors(
+        self,
+    ) -> list[tuple[tuple[float, float], tuple[float, float]]]:
+        return self._floor_plan_doors
+
+    @property
+    def floor_plan_scale(self) -> float:
+        return self._floor_plan_scale
+
+    @property
+    def floor_plan_origin(self) -> tuple[float, float]:
+        return self._floor_plan_origin
+
+    @property
+    def connection_status(self) -> str:
+        return self._connection_status
+
+    def update_from_response(self, device_data: dict[str, Any]) -> None:
+        """Update device state from a fresh Skegox API response."""
+        telemetry = device_data.get("telemetry", {})
+        shadow = device_data.get("shadow", {})
+        reported = shadow.get("properties", {}).get("reported", {})
+        connectivity = device_data.get("connectivityStatus", {})
+
+        self._connection_status = (
+            "Online" if connectivity.get("connected") else "Offline"
+        )
+
+        for key, value in telemetry.items():
+            self.properties_full[f"GET_{key}"] = {"value": value}
+
+        for key, val_obj in reported.items():
+            if isinstance(val_obj, dict):
+                self.properties_full[f"GET_{key}"] = val_obj
+            else:
+                self.properties_full[f"GET_{key}"] = {"value": val_obj}
+
+def _read_varint(data: bytes, pos: int) -> tuple[int, int]:
+    """Read a protobuf varint, returning (value, new_position)."""
+    result = 0
+    shift = 0
+    while pos < len(data):
+        byte = data[pos]
+        result |= (byte & 0x7F) << shift
+        pos += 1
+        if (byte & 0x80) == 0:
+            break
+        shift += 7
+    return result, pos
+
+def _transform_coord(x: float, y: float) -> tuple[float, float]:
+    """Transform protobuf local grid coordinates to JSON centimeter coordinates."""
+    x_json = -_COORD_SCALE * x + _COORD_X_OFFSET
+    y_json = _COORD_SCALE * y + _COORD_Y_OFFSET
+    return x_json, y_json
+
+def _parse_room_protobuf(data: bytes) -> tuple[str, list[tuple[float, float]]]:
+    """Parse a room entry from protobuf. Returns (name, list of (x, y) points)."""
+    rp = 0
+    room_name = ""
+    points: list[tuple[float, float]] = []
+
+    while rp < len(data):
+        tag, rp = _read_varint(data, rp)
+        fn = tag >> 3
+        wt = tag & 7
+
+        if wt != 2:
+            continue
+
+        field_len, rp = _read_varint(data, rp)
+        field_data = data[rp : rp + field_len]
+        rp += field_len
+
+        if fn == 2:
+            room_name = field_data.decode("utf-8")
+
+        elif fn == 4:
+            pp = 0
+            while pp < len(field_data):
+                ptag, pp = _read_varint(field_data, pp)
+                pfn = ptag >> 3
+                pwt = ptag & 7
+
+                if pwt != 2:
+                    continue
+
+                plen, pp = _read_varint(field_data, pp)
+                pdata = field_data[pp : pp + plen]
+                pp += plen
+
+                if len(pdata) >= 10:
+                    x_raw = struct.unpack("<f", pdata[1:5])[0]
+                    y_raw = struct.unpack("<f", pdata[6:10])[0]
+                    points.append(_transform_coord(x_raw, y_raw))
+
+    return room_name, points
+
+def _parse_nogo_protobuf(
+    data: bytes,
+) -> tuple[str, list[tuple[float, float]], str]:
+    """Parse a no-go zone entry from protobuf. Returns (uuid, points, type)."""
+    np = 0
+    uuid_val = ""
+    zone_type = ""
+    points: list[tuple[float, float]] = []
+
+    while np < len(data):
+        tag, np = _read_varint(data, np)
+        fn = tag >> 3
+        wt = tag & 7
+
+        if wt == 0:
+            _, np = _read_varint(data, np)
+            continue
+
+        if wt != 2:
+            continue
+
+        field_len, np = _read_varint(data, np)
+        field_data = data[np : np + field_len]
+        np += field_len
+
+        if fn in (2, 3):
+            uuid_val = field_data.decode("utf-8")
+
+        elif fn == 16:
+            zone_type = field_data.decode("utf-8")
+
+        elif fn == 4:
+            pp = 0
+            while pp < len(field_data):
+                ptag, pp = _read_varint(field_data, pp)
+                pfn = ptag >> 3
+                pwt = ptag & 7
+
+                if pwt != 2:
+                    continue
+
+                plen, pp = _read_varint(field_data, pp)
+                pdata = field_data[pp : pp + plen]
+                pp += plen
+
+                if len(pdata) >= 10:
+                    x_raw = struct.unpack("<f", pdata[1:5])[0]
+                    y_raw = struct.unpack("<f", pdata[6:10])[0]
+                    points.append(_transform_coord(x_raw, y_raw))
+
+    return uuid_val, points, zone_type

--- a/sharkiq/skegox_device.py
+++ b/sharkiq/skegox_device.py
@@ -12,6 +12,7 @@ import logging
 import struct
 from typing import TYPE_CHECKING, Any
 
+from .const import AYLA_TO_SKEGOX_POWER, SKEGOX_TO_AYLA_POWER
 from .sharkiq import ERROR_MESSAGES
 
 if TYPE_CHECKING:
@@ -54,12 +55,7 @@ OP_MODE_PAUSE = 1
 OP_MODE_START = 2
 OP_MODE_RETURN = 3
 
-POWER_ECO = 1
-POWER_NORMAL = 0
-POWER_MAX = 2
 
-AYLA_TO_SKEGOX_POWER = {POWER_ECO: 0, POWER_NORMAL: 1, POWER_MAX: 2}
-SKEGOX_TO_AYLA_POWER = {v: k for k, v in AYLA_TO_SKEGOX_POWER.items()}
 
 class SkegoxDevice:
     """Represents a Shark vacuum via the Skegox API.
@@ -459,7 +455,7 @@ class SkegoxDevice:
                 elif length >= 3:
                     pp = 0
                     while pp < len(fd) and idx < palette_count:
-                        if pp + 3 < len(fd):
+                        if pp + 3 <= len(fd):
                             r = fd[pp]
                             g = fd[pp + 1]
                             b = fd[pp + 2]
@@ -628,8 +624,7 @@ class SkegoxDevice:
             wt = tag & 7
 
             if wt != 2:
-                if wt == 0:
-                    _, cp = _read_varint(container, cp)
+                cp = _skip_protobuf_field(container, cp, wt)
                 continue
 
             field_len, cp = _read_varint(container, cp)
@@ -761,6 +756,20 @@ def _read_varint(data: bytes, pos: int) -> tuple[int, int]:
         shift += 7
     return result, pos
 
+
+def _skip_protobuf_field(data: bytes, pos: int, wt: int) -> int:
+    """Skip a protobuf field value based on wire type. Returns new position."""
+    if wt == 0:  # varint
+        _, pos = _read_varint(data, pos)
+    elif wt == 1:  # 64-bit
+        pos += 8
+    elif wt == 5:  # 32-bit
+        pos += 4
+    else:
+        raise ValueError(f"Unexpected wire type {wt}")
+    return pos
+
+
 def _transform_coord(x: float, y: float) -> tuple[float, float]:
     """Transform protobuf local grid coordinates to JSON centimeter coordinates."""
     x_json = -_COORD_SCALE * x + _COORD_X_OFFSET
@@ -796,6 +805,7 @@ def _parse_room_protobuf(data: bytes) -> tuple[str, list[tuple[float, float]]]:
                 pwt = ptag & 7
 
                 if pwt != 2:
+                    pp = _skip_protobuf_field(field_data, pp, pwt)
                     continue
 
                 plen, pp = _read_varint(field_data, pp)
@@ -828,6 +838,7 @@ def _parse_nogo_protobuf(
             continue
 
         if wt != 2:
+            np = _skip_protobuf_field(data, np, wt)
             continue
 
         field_len, np = _read_varint(data, np)
@@ -848,6 +859,7 @@ def _parse_nogo_protobuf(
                 pwt = ptag & 7
 
                 if pwt != 2:
+                    pp = _skip_protobuf_field(field_data, pp, pwt)
                     continue
 
                 plen, pp = _read_varint(field_data, pp)

--- a/sharkiq/utils.py
+++ b/sharkiq/utils.py
@@ -1,0 +1,35 @@
+"""Shared utilities for Shark IQ backends."""
+
+import enum
+from typing import Any, Optional
+
+
+def clean_property_name(raw_property_name: str) -> str:
+    """Clean up property names by removing SET_ or GET_ prefix.
+
+    Args:
+        raw_property_name: The raw property name.
+
+    Returns:
+        The cleaned property name.
+    """
+    if len(raw_property_name) >= 4 and raw_property_name[:4].upper() in ('SET_', 'GET_'):
+        return raw_property_name[4:]
+    return raw_property_name
+
+
+def resolve_enum_value(value: Any, default: Optional[Any] = None) -> Any:
+    """Extract the value from an enum or return as-is.
+
+    Args:
+        value: The value to resolve (may be an enum).
+        default: Default value if input is None.
+
+    Returns:
+        The enum value if input was an enum, otherwise the input itself.
+    """
+    if value is None:
+        return default
+    if hasattr(value, 'value'):
+        return value.value
+    return value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 import os
 from sharkiq.ayla_api import get_ayla_api
@@ -33,5 +35,5 @@ def sample_api():
 @pytest.fixture
 def sample_api_logged_in(sample_api):
     """Sample API object with user-supplied creds after performing auth flow."""
-    sample_api.sign_in()
+    asyncio.run(sample_api.async_sign_in())
     return sample_api

--- a/tests/test_skegox_api.py
+++ b/tests/test_skegox_api.py
@@ -1,0 +1,88 @@
+import pytest
+from sharkiq.skegox_api import SkegoxApi, SkegoxApiError
+
+class MockAuthManager:
+    def __init__(self):
+        from sharkiq.const import REGION_ELSEWHERE, REGION_CONFIGS
+        self._region = REGION_CONFIGS[REGION_ELSEWHERE]
+        self._id_token = "test_id_token"
+        self._household_id = "hh1"
+        self._user_id = "u1"
+
+    @property
+    def region(self):
+        return self._region
+
+    @property
+    def id_token(self):
+        return self._id_token
+
+    @property
+    def household_id(self):
+        return self._household_id
+
+    @property
+    def user_id(self):
+        return self._user_id
+
+    def set_user_id(self, uid):
+        self._user_id = uid
+
+    def set_household_id(self, hid):
+        self._household_id = hid
+
+    async def ensure_authenticated(self, force_refresh=False):
+        return self._id_token
+
+
+class TestSkegoxApiInit:
+    def test_init(self):
+        auth = MockAuthManager()
+        api = SkegoxApi(auth)
+        assert api._auth is auth
+
+    def test_headers(self):
+        auth = MockAuthManager()
+        api = SkegoxApi(auth)
+        headers = api._headers()
+        assert headers["Authorization"] == "Bearer test_id_token"
+        assert "x-api-key" in headers
+        assert "x-iotn-request-signature" in headers
+        assert headers["x-iotn-caller"] == "ENDUSER_MOBILEAPP"
+
+    def test_clear_property_file_cache(self):
+        auth = MockAuthManager()
+        api = SkegoxApi(auth)
+        api._property_file_cache["snd1"] = ([], 0)
+        api._property_file_cache["snd2"] = ([], 0)
+        api.clear_property_file_cache("snd1")
+        assert "snd1" not in api._property_file_cache
+        assert "snd2" in api._property_file_cache
+
+    def test_clear_property_file_cache_all(self):
+        auth = MockAuthManager()
+        api = SkegoxApi(auth)
+        api._property_file_cache["snd1"] = ([], 0)
+        api.clear_property_file_cache()
+        assert len(api._property_file_cache) == 0
+
+    @pytest.mark.asyncio
+    async def test_close(self):
+        auth = MockAuthManager()
+        api = SkegoxApi(auth)
+        session = await api._get_session()
+        await api.close()
+        assert session.closed
+        assert api._session is None
+
+    def test_send_command_unknown(self, caplog):
+        auth = MockAuthManager()
+        api = SkegoxApi(auth)
+        api.send_command("snd1", "unknown_cmd")
+        assert "Unknown command" in caplog.text
+
+    def test_set_fan_speed_unknown(self, caplog):
+        auth = MockAuthManager()
+        api = SkegoxApi(auth)
+        api.set_fan_speed("snd1", "turbo")
+        assert "Unknown fan speed" in caplog.text

--- a/tests/test_skegox_api.py
+++ b/tests/test_skegox_api.py
@@ -1,5 +1,9 @@
+import asyncio
+
 import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 from sharkiq.skegox_api import SkegoxApi, SkegoxApiError
+
 
 class MockAuthManager:
     def __init__(self):
@@ -33,6 +37,21 @@ class MockAuthManager:
 
     async def ensure_authenticated(self, force_refresh=False):
         return self._id_token
+
+
+def _create_mock_api():
+    """Helper to create a SkegoxApi with initialized session."""
+    auth = MockAuthManager()
+    api = SkegoxApi(auth)
+    # Check if we're in an async context (pytest-asyncio provides running loop)
+    try:
+        asyncio.get_running_loop()
+        # We're in an async context - can't use run_until_complete, so just create the session directly
+        # The test will call _get_session() when needed
+    except RuntimeError:
+        # No running loop - safe to use run_until_complete
+        asyncio.get_event_loop().run_until_complete(api._get_session())
+    return api
 
 
 class TestSkegoxApiInit:
@@ -75,14 +94,118 @@ class TestSkegoxApiInit:
         assert session.closed
         assert api._session is None
 
-    def test_send_command_unknown(self, caplog):
-        auth = MockAuthManager()
-        api = SkegoxApi(auth)
-        api.send_command("snd1", "unknown_cmd")
+    @pytest.mark.asyncio
+    async def test_send_command_unknown(self, caplog):
+        mock_api = _create_mock_api()
+        await mock_api._get_session()
+        await mock_api.send_command("snd1", "unknown_cmd")
         assert "Unknown command" in caplog.text
 
-    def test_set_fan_speed_unknown(self, caplog):
-        auth = MockAuthManager()
-        api = SkegoxApi(auth)
-        api.set_fan_speed("snd1", "turbo")
+    @pytest.mark.asyncio
+    async def test_set_fan_speed_unknown(self, caplog):
+        mock_api = _create_mock_api()
+        await mock_api._get_session()
+        await mock_api.set_fan_speed("snd1", "turbo")
         assert "Unknown fan speed" in caplog.text
+
+
+class TestSkegoxApiRequests:
+    """Tests for Skegox API HTTP request methods with mocked responses."""
+
+    @pytest.mark.asyncio
+    async def test_request_success(self):
+        """Test successful API request returns parsed JSON."""
+        mock_api = _create_mock_api()
+        await mock_api._get_session()  # Ensure session exists in async context
+        mock_response_data = {"items": [{"deviceId": "snd1"}]}
+
+        with patch.object(mock_api, '_request', new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = mock_response_data
+
+            result = await mock_api._request("GET", "/test")
+            assert result == mock_response_data
+
+    @pytest.mark.asyncio
+    async def test_request_error_raises(self):
+        """Test API error raises SkegoxApiError."""
+        mock_api = _create_mock_api()
+        with patch.object(mock_api, '_request', new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = SkegoxApiError("Skegox error (500): Internal Server Error")
+
+            with pytest.raises(SkegoxApiError, match=r"Skegox error \(500\)"):
+                await mock_req()
+
+
+class TestSkegoxApiDiscovery:
+    """Tests for device discovery methods."""
+
+    @pytest.mark.asyncio
+    async def test_list_devices(self):
+        """Test listing devices returns parsed items."""
+        mock_api = _create_mock_api()
+        await mock_api._get_session()  # Ensure session exists in async context
+        mock_response_data = {"items": [
+            {"deviceId": "snd1", "name": "Robot 1"},
+            {"deviceId": "snd2", "name": "Robot 2"}
+        ]}
+
+        with patch.object(mock_api, '_request', new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = mock_response_data
+
+            result = await mock_api.list_devices()
+            assert len(result) == 2
+            assert result[0]["deviceId"] == "snd1"
+
+    @pytest.mark.asyncio
+    async def test_get_device(self):
+        """Test getting a single device by SND."""
+        mock_api = _create_mock_api()
+        await mock_api._get_session()  # Ensure session exists in async context
+        mock_response_data = {"deviceId": "snd1", "shadow": {}}
+
+        with patch.object(mock_api, '_request', new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = mock_response_data
+
+            result = await mock_api.get_device("snd1")
+            assert result["deviceId"] == "snd1"
+
+
+class TestSkegoxPropertyFiles:
+    """Tests for property file operations."""
+
+    @pytest.mark.asyncio
+    async def test_list_property_files(self):
+        """Test listing property files for a device."""
+        mock_api = _create_mock_api()
+        await mock_api._get_session()  # Ensure session exists in async context
+        mock_response_data = {"files": [
+            {"name": "floorRPfile1", "url": "https://example.com/file1"},
+            {"name": "mard_data", "url": "https://example.com/mard"}
+        ]}
+
+        with patch.object(mock_api, '_request', new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = mock_response_data
+
+            result = await mock_api.list_property_files("snd1")
+            assert len(result) == 2
+            assert result[0]["name"] == "floorRPfile1"
+
+    @pytest.mark.asyncio
+    async def test_list_property_files_empty(self):
+        """Test listing property files returns empty list on error."""
+        mock_api = _create_mock_api()
+        with patch.object(mock_api, '_request', new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = Exception("Network error")
+
+            result = await mock_api.list_property_files("snd1")
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_fetch_property_file_not_found(self):
+        """Test fetching non-existent property file returns None."""
+        mock_api = _create_mock_api()
+        # Empty cache - no files listed
+        mock_api._property_file_cache["snd1"] = ([], 0)
+
+        result = await mock_api.fetch_property_file("snd1", "nonexistent")
+        assert result is None

--- a/tests/test_skegox_auth.py
+++ b/tests/test_skegox_auth.py
@@ -116,7 +116,7 @@ class TestSkegoxAuthManager:
             password="password123",
             region=REGION_EUROPE,
         )
-        assert REGION_EUROPE in mgr.region.auth0_url
+        assert "logineu" in mgr.region.auth0_url
 
     def test_save_tokens_calls_callback(self):
         saved = []

--- a/tests/test_skegox_auth.py
+++ b/tests/test_skegox_auth.py
@@ -1,0 +1,178 @@
+import pytest
+from sharkiq.skegox_auth import SkegoxAuthManager, AuthTokens
+from sharkiq.const import REGION_ELSEWHERE, REGION_EUROPE
+from sharkiq.exc import (
+    SkegoxAuthError,
+    SkegoxAuthRequiresVerificationError,
+    SkegoxAuthLockedError,
+)
+from datetime import datetime, timedelta, timezone
+
+class TestAuthTokens:
+    def test_to_dict(self):
+        tokens = AuthTokens(
+            auth0_id_token="id123",
+            auth0_refresh_token="ref456",
+            auth0_access_token="acc789",
+            auth0_expiry=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            household_id="hh1",
+            user_id="u1",
+        )
+        d = tokens.to_dict()
+        assert d["auth0_id_token"] == "id123"
+        assert d["auth0_refresh_token"] == "ref456"
+        assert d["auth0_access_token"] == "acc789"
+        assert d["household_id"] == "hh1"
+        assert d["user_id"] == "u1"
+
+    def test_from_dict(self):
+        d = {
+            "auth0_id_token": "id123",
+            "auth0_refresh_token": "ref456",
+            "auth0_access_token": "acc789",
+            "auth0_expiry": "2026-01-01T00:00:00+00:00",
+            "household_id": "hh1",
+            "user_id": "u1",
+        }
+        tokens = AuthTokens.from_dict(d)
+        assert tokens.auth0_id_token == "id123"
+        assert tokens.auth0_refresh_token == "ref456"
+        assert tokens.auth0_access_token == "acc789"
+        assert tokens.household_id == "hh1"
+        assert tokens.user_id == "u1"
+
+    def test_from_dict_invalid_expiry(self):
+        d = {"auth0_expiry": "not-a-date"}
+        tokens = AuthTokens.from_dict(d)
+        assert tokens.auth0_expiry is None
+
+    def test_auth0_token_valid(self):
+        tokens = AuthTokens(
+            auth0_id_token="id123",
+            auth0_expiry=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        assert tokens.auth0_token_valid is True
+
+    def test_auth0_token_expired(self):
+        tokens = AuthTokens(
+            auth0_id_token="id123",
+            auth0_expiry=datetime.now(timezone.utc) - timedelta(hours=1),
+        )
+        assert tokens.auth0_token_valid is False
+
+    def test_auth0_token_no_expiry(self):
+        tokens = AuthTokens(auth0_id_token="id123")
+        assert tokens.auth0_token_valid is False
+
+    def test_ayla_token_expiring_soon(self):
+        tokens = AuthTokens(
+            ayla_access_token="abc",
+            ayla_expiry=datetime.now(timezone.utc) + timedelta(minutes=2),
+        )
+        assert tokens.ayla_token_expiring_soon is True
+
+    def test_ayla_token_not_expiring(self):
+        tokens = AuthTokens(
+            ayla_access_token="abc",
+            ayla_expiry=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        assert tokens.ayla_token_expiring_soon is False
+
+    def test_ayla_token_expiring_no_token(self):
+        tokens = AuthTokens()
+        assert tokens.ayla_token_expiring_soon is True
+
+class TestSkegoxAuthManager:
+    def _make_manager(self, token_store=None, on_tokens_changed=None):
+        return SkegoxAuthManager(
+            username="test@example.com",
+            password="password123",
+            region=REGION_ELSEWHERE,
+            token_store=token_store,
+            on_tokens_changed=on_tokens_changed,
+        )
+
+    def test_init_defaults(self):
+        mgr = self._make_manager()
+        assert mgr.region.skegox_api_key is not None
+        assert mgr.id_token is None
+        assert mgr.household_id is None
+        assert mgr.user_id is None
+
+    def test_init_with_token_store(self):
+        store = {
+            "auth0_id_token": "id123",
+            "household_id": "hh1",
+            "user_id": "u1",
+        }
+        mgr = self._make_manager(token_store=store)
+        assert mgr.id_token == "id123"
+        assert mgr.household_id == "hh1"
+        assert mgr.user_id == "u1"
+
+    def test_europe_region(self):
+        mgr = SkegoxAuthManager(
+            username="test@example.com",
+            password="password123",
+            region=REGION_EUROPE,
+        )
+        assert REGION_EUROPE in mgr.region.auth0_url
+
+    def test_save_tokens_calls_callback(self):
+        saved = []
+        mgr = self._make_manager(on_tokens_changed=lambda d: saved.append(d))
+        mgr.set_user_id("u1")
+        assert len(saved) == 1
+        assert saved[0]["user_id"] == "u1"
+
+    def test_save_tokens_no_callback(self):
+        mgr = self._make_manager()
+        mgr.set_user_id("u1")
+        assert mgr.user_id == "u1"
+
+    def test_set_household_id(self):
+        mgr = self._make_manager()
+        mgr.set_household_id("hh123")
+        assert mgr.household_id == "hh123"
+
+    def test_set_user_id(self):
+        mgr = self._make_manager()
+        mgr.set_user_id("u123")
+        assert mgr.user_id == "u123"
+
+    def test_update_ayla_tokens(self):
+        mgr = self._make_manager()
+        expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+        mgr.update_ayla_tokens("ayla_acc", "ayla_ref", expiry)
+        assert mgr.ayla_access_token == "ayla_acc"
+        assert mgr.ayla_refresh_token == "ayla_ref"
+
+    def test_tokens_property(self):
+        mgr = self._make_manager()
+        assert isinstance(mgr.tokens, AuthTokens)
+
+    @pytest.mark.asyncio
+    async def test_ensure_authenticated_uses_cached_token(self):
+        store = {
+            "auth0_id_token": "cached_id_token",
+            "auth0_expiry": (
+                datetime.now(timezone.utc) + timedelta(hours=1)
+            ).isoformat(),
+        }
+        mgr = self._make_manager(token_store=store)
+        result = await mgr.ensure_authenticated()
+        assert result == "cached_id_token"
+
+    @pytest.mark.asyncio
+    async def test_ensure_authenticated_force_refresh_no_refresh_token(self):
+        mgr = self._make_manager()
+        with pytest.raises(SkegoxAuthError, match="All authentication methods failed"):
+            await mgr.ensure_authenticated(force_refresh=True)
+
+    @pytest.mark.asyncio
+    async def test_close(self):
+        mgr = self._make_manager()
+        session = await mgr._get_session()
+        assert not session.closed
+        await mgr.close()
+        assert session.closed

--- a/tests/test_skegox_device.py
+++ b/tests/test_skegox_device.py
@@ -1,0 +1,196 @@
+import pytest
+from sharkiq.skegox_device import (
+    SkegoxDevice,
+    AYLA_TO_SKEGOX_POWER,
+    SKEGOX_TO_AYLA_POWER,
+    _read_varint,
+    _transform_coord,
+)
+
+def _make_device(api, device_data):
+    return SkegoxDevice(api, device_data)
+
+def _minimal_device_data(snd="ABC123"):
+    return {
+        "_snd": snd,
+        "metadata": {"deviceName": "Test Shark"},
+        "registry": {
+            "Device_Serial_Num": "SN-001",
+            "Device_Model_Number": "RV900",
+            "Battery_Serial_Num": "BAT-ABC123",
+        },
+        "telemetry": {"Battery_Capacity": 85, "RSSI": -50},
+        "connectivityStatus": {"connected": True},
+        "shadow": {
+            "properties": {
+                "reported": {
+                    "Operating_Mode": {"value": 0},
+                    "Power_Mode": {"value": 1},
+                    "Error_Code": {"value": 0},
+                    "Robot_Room_List": {"value": "Floor1:Kitchen:Living Room:Bedroom"},
+                }
+            }
+        },
+    }
+
+class TestSkegoxDeviceCreation:
+    def test_extract_snd(self):
+        assert SkegoxDevice.extract_snd({"Battery_Serial_Num": "BAT-XYZ789"}) == "XYZ789"
+
+    def test_extract_snd_no_dash(self):
+        assert SkegoxDevice.extract_snd({"Battery_Serial_Num": "XYZ789"}) == "XYZ789"
+
+    def test_basic_properties(self):
+        api = None
+        data = _minimal_device_data()
+        device = _make_device(api, data)
+        assert device.serial_number == "ABC123"
+        assert device.name == "Test Shark"
+        assert device.oem_model_number == "SN-001"
+        assert device.connection_status == "Online"
+
+    def test_connection_status_offline(self):
+        data = _minimal_device_data()
+        data["connectivityStatus"]["connected"] = False
+        device = _make_device(None, data)
+        assert device.connection_status == "Offline"
+
+class TestPropertyAccess:
+    def test_get_property_value_direct(self):
+        data = _minimal_device_data()
+        device = _make_device(None, data)
+        assert device.get_property_value("Battery_Capacity") == 85
+
+    def test_get_property_value_get_prefix(self):
+        data = _minimal_device_data()
+        device = _make_device(None, data)
+        assert device.get_property_value("GET_Battery_Capacity") == 85
+
+    def test_get_property_value_missing(self):
+        data = _minimal_device_data()
+        device = _make_device(None, data)
+        assert device.get_property_value("Nonexistent") is None
+
+    def test_power_mode_translation(self):
+        data = _minimal_device_data()
+        device = _make_device(None, data)
+        val = device.get_property_value("Power_Mode")
+        assert val == 0
+
+    def test_error_text_no_error(self):
+        data = _minimal_device_data()
+        device = _make_device(None, data)
+        assert device.error_text is None
+
+    def test_error_text_with_error(self):
+        data = _minimal_device_data()
+        data["shadow"]["properties"]["reported"]["Error_Code"] = {"value": 4}
+        device = _make_device(None, data)
+        assert "Brushroll" in device.error_text
+
+    def test_error_text_unknown(self):
+        data = _minimal_device_data()
+        data["shadow"]["properties"]["reported"]["Error_Code"] = {"value": 99}
+        device = _make_device(None, data)
+        assert "Unknown error (99)" in device.error_text
+
+class TestRoomParsing:
+    def test_parse_room_list_legacy(self):
+        data = _minimal_device_data()
+        device = _make_device(None, data)
+        assert device._floor_id == "Floor1"
+        assert device._rooms == ["Kitchen", "Living Room", "Bedroom"]
+
+    def test_parse_areas_json_v3_dict(self):
+        data = _minimal_device_data()
+        data["shadow"]["properties"]["reported"]["Robot_Room_List"] = {"value": ""}
+        data["shadow"]["properties"]["reported"]["AreasToClean_V3"] = {
+            "value": '{"floor_id": "F2", "areas_to_clean": {"UserRoom": ["Kitchen", "Den"]}}'
+        }
+        device = _make_device(None, data)
+        assert device._floor_id == "F2"
+        assert device._rooms == ["Kitchen", "Den"]
+
+    def test_parse_areas_json_v2_list(self):
+        data = _minimal_device_data()
+        data["shadow"]["properties"]["reported"]["Robot_Room_List"] = {"value": ""}
+        data["shadow"]["properties"]["reported"]["Areas_To_Clean"] = {
+            "value": '{"floor_id": "F3", "areas_to_clean": ["UserRoom:Kitchen", "UserRoom:Den"]}'
+        }
+        device = _make_device(None, data)
+        assert device._floor_id == "F3"
+        assert device._rooms == ["Kitchen", "Den"]
+
+class TestPowerModeTranslation:
+    def test_ayla_to_skegox(self):
+        assert AYLA_TO_SKEGOX_POWER[1] == 0
+        assert AYLA_TO_SKEGOX_POWER[0] == 1
+        assert AYLA_TO_SKEGOX_POWER[2] == 2
+
+    def test_skegox_to_ayla(self):
+        assert SKEGOX_TO_AYLA_POWER[0] == 1
+        assert SKEGOX_TO_AYLA_POWER[1] == 0
+        assert SKEGOX_TO_AYLA_POWER[2] == 2
+
+class TestUpdateFromResponse:
+    def test_update_telemetry(self):
+        data = _minimal_device_data()
+        device = _make_device(None, data)
+        device.update_from_response({
+            "telemetry": {"Battery_Capacity": 50},
+            "shadow": {"properties": {"reported": {}}},
+            "connectivityStatus": {"connected": True},
+        })
+        assert device.get_property_value("GET_Battery_Capacity") == 50
+
+    def test_update_connectivity(self):
+        data = _minimal_device_data()
+        device = _make_device(None, data)
+        device.update_from_response({
+            "telemetry": {},
+            "shadow": {"properties": {"reported": {}}},
+            "connectivityStatus": {"connected": False},
+        })
+        assert device.connection_status == "Offline"
+
+class TestHelpers:
+    def test_read_varint_single_byte(self):
+        val, pos = _read_varint(b"\x00", 0)
+        assert val == 0
+        assert pos == 1
+
+    def test_read_varint_multi_byte(self):
+        val, pos = _read_varint(b"\x80\x01", 0)
+        assert val == 128
+        assert pos == 2
+
+    def test_transform_coord(self):
+        x, y = _transform_coord(0.0, 0.0)
+        assert x == 134.5
+        assert y == 203.5
+
+class TestMARDJson:
+    def test_load_mard_json_rooms(self):
+        data = _minimal_device_data()
+        data["shadow"]["properties"]["reported"]["Robot_Room_List"] = {"value": ""}
+        device = _make_device(None, data)
+        mard = {
+            "floor_id": "FloorA",
+            "areas": [
+                {
+                    "area_meta_data": "UserRoom:Kitchen",
+                    "robot_room_name": "Kitchen",
+                    "user_room_name": "Kitchen",
+                    "points": [{"x": 0, "y": 0}, {"x": 100, "y": 0}, {"x": 100, "y": 100}],
+                },
+                {
+                    "area_meta_data": "UserNoGo:uuid-123",
+                    "area_state": "blocking",
+                    "points": [{"x": 10, "y": 10}, {"x": 20, "y": 10}, {"x": 20, "y": 20}],
+                },
+            ],
+        }
+        device._load_mard_json(mard)
+        assert device._floor_id == "FloorA"
+        assert "Kitchen" in device._rooms
+        assert len(device._no_go_zones) == 1


### PR DESCRIPTION
# Add Skegox API backend for newer SharkNinja devices

## Summary

This PR adds full support for the **Skegox cloud API** — the newer SharkNinja backend used by recent vacuum models (Matrix, PowerDetect, Stratos, etc.) — alongside the existing Ayla Networks API.

The Skegox API uses an IoT shadow model (reported/desired properties) instead of the Ayla property datapoint model. This implementation provides a `SkegoxDevice` class that implements the same public interface as `SharkIqVacuum`, so consumer code works unchanged regardless of backend.

## What's New

### `skegox_auth.py` — Auth0 authentication manager
- `SkegoxAuthManager` with full auth cascade: cached tokens → refresh_token grant → password grant
- Callback-based token persistence (no framework-specific dependencies)
- Region-specific Auth0 endpoints and credentials (elsewhere + EU)
- JWT expiry decoding, Ayla token passthrough, household/user ID discovery

### `skegox_api.py` — Async Skegox cloud API client
- Device discovery (user ID from JWT, household ID from API)
- Device listing and full state retrieval
- Property file fetching (MARD zones, floor plan protobufs) with 5-min cache
- Shadow-based commands: start/stop/pause/return, fan speed, room cleaning
- Automatic 401 auth refresh + retry
- HMAC signature headers (syntactically valid)

### `skegox_device.py` — Device model (mirrors `SharkIqVacuum` interface)
- `get_property_value()` / `async_set_property_value()` with GET_ prefix handling
- Power mode translation between Ayla (ECO=1, NORMAL=0, MAX=2) and Skegox (ECO=0, NORMAL=1, MAX=2)
- Room list parsing from `Robot_Room_List`, `AreasToClean_V3`, `Areas_To_Clean`
- MARD parsing: both JSON and base64-encoded protobuf formats
- Floor plan protobuf parsing: room polygons, no-go zones, edge/door lines, palette-indexed image
- `update_from_response()` for incremental state updates

### Updated existing modules
| File | Changes |
|---|---|
| `const.py` | `RegionConfig` dataclass, `REGION_CONFIGS` (elsewhere + EU), `API_TIMEOUT` |
| `exc.py` | `SkegoxApiError`, `SkegoxAuthError`, `SkegoxAuthRequiresVerificationError`, `SkegoxAuthLockedError`, `SharkIqAuthVerificationRequiredError` |
| `sharkiq.py` | Expanded `ERROR_MESSAGES` (22 codes), ayla_api verification error handling |
| `ayla_api.py` | Raise `SharkIqAuthVerificationRequiredError` on anti-bot detection |
| `__init__.py` | Export all Skegox classes + `get_skegox_api()` factory |
| `pyproject.toml` | `protobuf` as required dep, `Pillow` as optional `[floorplan]` dep |

## Tests

- `test_skegox_auth.py` — token lifecycle, auth cascade, callback persistence, error handling
- `test_skegox_api.py` — init, headers, cache management, command validation
- `test_skegox_device.py` — property access, room parsing (JSON + protobuf), power mode translation, MARD loading

## API Comparison

| Feature | Ayla API | Skegox API |
|---|---|---|
| Auth | `async_sign_in()` → access/refresh tokens | Auth0 password grant → id_token → Bearer |
| Device list | `GET /apiv1/devices.json` | `GET /devicesEndUserController/{hh}/users/{uid}` |
| State fetch | `GET /apiv1/dsns/{dsn}/properties.json` | `GET /devicesEndUserController/{hh}/devices/{snd}` |
| Commands | `POST /properties/{name}/datapoints.json` | `PATCH` with `shadow.properties.desired` |
| Room cleaning | Base64-encoded binary payload | JSON with `floor_id`, `areas_to_clean`, `clean_count` |
| Property names | `Operating_Mode`, `Battery_Capacity` | `GET_Operating_Mode`, `GET_Battery_Capacity` |

## Notes

- **PIL is optional** — floor plan image parsing degrades gracefully if Pillow is not installed; edges/doors/rooms still parse fine
- **Token persistence via callback** — `on_tokens_changed: Callable[[dict], None]` allows any consumer (HA, CLI, etc.) to handle storage
- **`ERROR_MESSAGES` in `sharkiq.py`** — both device classes import from the same source
- **`get_skegox_api()` factory** — mirrors `get_ayla_api()` pattern for API consistency